### PR TITLE
`require` to work in all versions of electron

### DIFF
--- a/electron/src/main.js
+++ b/electron/src/main.js
@@ -22,7 +22,8 @@ function init() {
     height: 900,
     resizable: true,
     webPreferences: {
-      webSecurity: false
+      webSecurity: false,
+      nodeIntegration: true
     }
   });
   mainWindow = window;


### PR DESCRIPTION
`nodeIntegration` is `false` by default in recent version of electron. Required to be true for `require` to work in the BrowserWindow.

As a side note, how do you cast the streams to a chromecast?